### PR TITLE
fix pybind11 build on clang by adding build_ext 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from distutils import spawn
 import os
 
 import subprocess
-from pybind11.setup_helpers import Pybind11Extension
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 import setuptools
 
 _PROJECT_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -113,6 +113,7 @@ def main():
       url='https://github.com/google/paranoid_crypto',
       install_requires=_parse_requirements('requirements.txt'),
       long_description=open('README.md').read(),
+      cmdclass={"build_ext": build_ext},
   )
 
 


### PR DESCRIPTION
By default, some clang versions, like those used on OSX, will default to an old C++ standard, which will cause the build to fail.

Adding pybind11's `build_ext` functionality will automatically search for the highest available C++ standard extension and use it, which fixes build issues.

Reference material:

https://github.com/pybind/pybind11/blob/master/pybind11/setup_helpers.py#L102
https://github.com/pybind/python_example/blob/master/setup.py#L39

I red/greened the build process when using `Apple clang version 13.1.6` and this change fixes the build, which failed prior.