### PR TITLE
fix FileNotFoundError not being raised

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,9 @@ def _get_protoc_command():
   if 'PROTOC' in os.environ and os.path.exists(os.environ['PROTOC']):
     return os.environ['PROTOC']
   else:
-    return spawn.find_executable('protoc')
+    filepath = spawn.find_executable('protoc')
+    if filepath is not None:
+      return filepath
   raise FileNotFoundError('Could not find protoc executable. Please install '
                           'protoc to compile the paranoid_crypto package.')
 


### PR DESCRIPTION
`spawn.find_executable` returns None when no executable is found. This was causing the `_get_protoc_command` to return None and not raising the error when no executable was found.

e.g.
```
>>> from distutils import spawn
>>> print(spawn.find_executable('foo'))
None
>>> print(spawn.find_executable('echo'))
/bin/echo
```
