### PR TITLE
pin Debian version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Install latest debian image
-FROM debian:latest
+# Install bullseye debian image
+FROM debian:bullseye
 
 # Create user
 RUN useradd -ms /bin/bash paranoid-user

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Clone the repository:
 
 ```$ git clone https://github.com/google/paranoid_crypto.git && cd paranoid_crypto```
 
-**NOTE**: The commands below have been tested on Debian latest stable version
+**NOTE**: The commands below have been tested on Debian oldstable version
 (bullseye). Make sure you will be using `python3.9` or newer.
 
 Install dependencies:


### PR DESCRIPTION
Build instructions do not work for bookworm, this PR pins the Debian version in the Dockerfile to bullseye so the repo can be built as is.

This is also a [good practice](https://docs.docker.com/develop/develop-images/guidelines/#pin-base-image-versions) to pin base image versions.
Once #19 is fixed, the Debian version should be updated to bookworm.